### PR TITLE
Adding a line break to the end of the list

### DIFF
--- a/src/bot/list.rs
+++ b/src/bot/list.rs
@@ -14,7 +14,7 @@ pub async fn handler(cx: UpdateWithCx<AutoSend<Bot>, Message>, db: Database) -> 
 
     for sale in sales {
         let line = format!(
-            "id: {}\nitem: {}\nseller: {}\ninteressados: {}",
+            "id: {}\nitem: {}\nseller: {}\ninteressados: {}\n",
             sale._id,
             sale.item,
             sale.seller,


### PR DESCRIPTION
It will avoid concatenating the last interested person and the next item's id.